### PR TITLE
Add Apple Silicon (MPS) GPU support

### DIFF
--- a/psauron/psauron.py
+++ b/psauron/psauron.py
@@ -76,13 +76,17 @@ def load_model(use_cpu):
     if torch.cuda.device_count() > 0 and not use_cpu:
         state_dict = torch.load(checkpoint)
     else:
-        state_dict = torch.load(checkpoint, map_location=torch.device('cpu'))
+        state_dict = torch.load(checkpoint, map_location=torch.device('mps' if torch.backends.mps.is_available() else 'cpu'))
         
     channel_sizes = [hidden_units_per_layer] * levels
     model = TCN(input_channels, n_classes, channel_sizes, kernel_size=kernel_size, dropout=dropout)
     model.load_state_dict(state_dict)
+    
     if torch.cuda.device_count() > 0 and not use_cpu:
         model.to('cuda')
+    elif torch.backends.mps.is_available() and not use_cpu:
+        model.to('mps')
+        
     model.eval()
     
     return model
@@ -173,6 +177,11 @@ def predict(X, model, use_cpu):
             probs = expit(model(X_enc).cpu())
             del X_enc
             torch.cuda.empty_cache()
+        elif torch.backends.mps.is_available() and not use_cpu:
+            X_enc = F.one_hot(X, 21).permute(0,2,1).float().to('mps')
+            probs = expit(model(X_enc).cpu())
+            del X_enc
+            torch.mps.empty_cache()
         else:
             X_enc = F.one_hot(X, 21).permute(0,2,1).float()
             probs = expit(model(X_enc).cpu())
@@ -405,7 +414,7 @@ def eye_of_psauron():
                 sys.exit()
             
             # score all frames with model
-            if torch.cuda.device_count() > 0:
+            if torch.cuda.device_count() > 0 or torch.backends.mps.is_available():
                 if not use_cpu:
                     print("Running TCN model on GPU...")
                 else:
@@ -469,7 +478,7 @@ def eye_of_psauron():
                 sys.exit()
             
             # score single frame with model
-            if torch.cuda.device_count() > 0:
+            if torch.cuda.device_count() > 0 or torch.backends.mps.is_available():
                 if not use_cpu:
                     print("Running TCN model on GPU...")
                 else:
@@ -538,7 +547,7 @@ def eye_of_psauron():
             sys.exit()
         
         # score single frame with model
-        if torch.cuda.device_count() > 0:
+        if torch.cuda.device_count() > 0 or torch.backends.mps.is_available():
             if not use_cpu:
                 print("Running TCN model on GPU...")
             else:


### PR DESCRIPTION
Hi there! I’ve been using this recently as part of TD2 and noticed that when running on a Mac, the code defaults to CPU.

PyTorch here is hardcoded to look exclusively for CUDA (torch.cuda) else it falls back to the CPU. PyTorch supports Apple Silicon (M<N>) natively via Metal Performance Shaders (mps).

This PR adds a small number of checks for mps to route to the Mac GPU, and it doesn't alter the existing CUDA or CPU logic.

Small edits to psauron.py:

- updated load_model to load the state_dict and then model to mps if available 
- small elif block in the predict function to send the input sequences to the mps device
- edited the print statements so the terminal says running on GPU

I tested this locally on my M3 MacBook with ~30x speedups vs CPU only. I haven't tested on a Linux+CUDA machine to double-check, but the original logic was preserved exactly as written.