### PR TITLE
Replace deprecated pkg_resources with importlib.resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.egg-info
 build/
 dist/
+__pycache__/
+psauron_score.csv

--- a/psauron/psauron.py
+++ b/psauron/psauron.py
@@ -6,8 +6,7 @@ import warnings
 import numpy as np
 from tqdm.auto import tqdm
 
-warnings.filterwarnings("ignore", message="pkg_resources is deprecated", category=UserWarning)
-import pkg_resources
+from importlib.resources import files
 
 from scipy.special import expit, logit
 
@@ -60,7 +59,7 @@ def get_args():
     
 def get_data_path():
     # gets correct path to model weight data for installed package
-    return pkg_resources.resource_filename(__name__, 'data/model_state_dict.pt')
+    return str(files('psauron').joinpath('data/model_state_dict.pt'))
     
 def load_model(use_cpu):
     # load TCN model

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
     
 setup(
     name="psauron",
-    version="1.1.1",
+    version="1.1.2",
     description="A tool to assess protein coding gene annotation",
     packages=find_packages(),
     long_description=long_description,
@@ -27,12 +27,11 @@ setup(
                       "tqdm>=4.66.1",
                       "scipy>=1.10.1",
                       "numpy>=1.24.4, <2",
-                      "pandas",
-                      "setuptools<81"],
+                      "pandas"],
     extras_require={
         "dev": ["pytest>=7.0", "twine>=4.0.2", "pytest-cov>=4.0", "wheel"],
     },
-    python_requires=">=3.9, <3.13",
+    python_requires=">=3.9, <3.14",
     entry_points={
         'console_scripts': [
             'psauron = psauron.psauron:eye_of_psauron',

--- a/tests/test_get_data_path.py
+++ b/tests/test_get_data_path.py
@@ -1,0 +1,47 @@
+import os
+
+from psauron.psauron import get_data_path
+
+
+def test_get_data_path_returns_string():
+    path = get_data_path()
+    assert isinstance(path, str)
+
+
+def test_get_data_path_file_exists():
+    path = get_data_path()
+    assert os.path.isfile(path), f"Model file not found at {path}"
+
+
+def test_get_data_path_correct_filename():
+    path = get_data_path()
+    assert path.endswith("model_state_dict.pt")
+
+
+def test_get_data_path_nonzero_size():
+    path = get_data_path()
+    assert os.path.getsize(path) > 0, "Model file is empty"
+
+
+def test_get_data_path_inside_package():
+    """Verify the model file is resolved within the psauron package directory."""
+    path = get_data_path()
+    parts = os.path.normpath(path).split(os.sep)
+    assert "psauron" in parts, f"Path does not appear to be inside the psauron package: {path}"
+    assert "data" in parts, f"Path does not include expected 'data' subdirectory: {path}"
+
+
+def test_no_pkg_resources_dependency():
+    """Confirm get_data_path works without pkg_resources being imported."""
+    import sys
+    # Temporarily hide pkg_resources from the import system
+    saved = sys.modules.get("pkg_resources")
+    sys.modules["pkg_resources"] = None
+    try:
+        path = get_data_path()
+        assert os.path.isfile(path)
+    finally:
+        if saved is not None:
+            sys.modules["pkg_resources"] = saved
+        else:
+            sys.modules.pop("pkg_resources", None)


### PR DESCRIPTION
- Use importlib.resources.files() to locate model data (stdlib since Python 3.9)
- Remove setuptools runtime dependency (was pinned <81, breaking bioconda builds)
- Extend python_requires to <3.14
- Add tests for data path resolution
- Bump version to 1.1.2